### PR TITLE
Add numerically-stable scattering-matrix backend (opt-in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,25 @@ absorption of a MoO₃/AlN/SiC heterostructure in the Otto geometry
 The amplitude transmission coefficients are also available via
 `FieldProfile.transmission_coefficients()` (and `Structure.calculate_transmissivity()`).
 
+## Numerical backends
+
+`execute` defaults to the 4×4 **transfer-matrix** method, which is fast but
+numerically unstable for thick / lossy / strongly-evanescent layers (the
+propagation terms grow exponentially and the matrix product overflows to `NaN`).
+For those cases, opt into the numerically-stable **scattering-matrix** backend:
+
+```python
+structure.execute(payload, backend="scattering")
+```
+
+It cascades per-layer scattering matrices with the Redheffer star product so only
+*decaying* exponentials ever appear. It returns the same reflection/transmission
+coefficients as the transfer method where that is well-conditioned, and correct
+ones where the transfer matrix is (near-)singular — e.g. a thick evanescent Otto
+gap, where `backend="transfer"` gives `NaN` but `backend="scattering"` correctly
+gives total reflection. Method/conventions follow PyLlama (Bay *et al.*,
+*J. Opt. Soc. Am. A* **39**, 1431 (2022)).
+
 ## Sweeping Layer Thickness
 
 A layer's `thickness` may be a **list** instead of a scalar, which sweeps it as a

--- a/hyperbolic_optics/scattering.py
+++ b/hyperbolic_optics/scattering.py
@@ -1,0 +1,164 @@
+"""Numerically-stable scattering-matrix backend.
+
+The default engine multiplies per-layer *transfer* matrices ``Mᵢ = Vᵢ·Pᵢ·Vᵢ⁻¹``
+with ``Pᵢ = diag(exp(-i·kz·k₀·d))`` (``waves.get_matrix``). For thick / lossy /
+strongly-evanescent layers the propagation diagonal mixes exponentially *growing*
+and *decaying* terms, so the products overflow and lose precision (energy
+conservation drifts, eventually ``NaN``).
+
+This module reformulates the same 4×4 anisotropic problem as a **scattering
+matrix** cascaded with the **Redheffer star product**, where every propagation
+factor is a *decaying* exponential (``exp(-|Im(kz)|·k₀·d) ≤ 1``) — the growing
+matrices are never materialised — so it is stable in all cases. It is the
+opt-in backend behind ``Structure.execute(payload, backend="scattering")`` and
+produces the same reflection/transmission coefficients as the transfer method
+where both are well-conditioned, and *correct* coefficients where the transfer
+method fails.
+
+Algorithm and conventions follow PyLlama (Bay, Lafait & Lequime / Bay et al.,
+J. Opt. Soc. Am. A 39, 1431 (2022); arXiv:2012.05945), eqs 18-28, adapted to this
+codebase's field-vector ordering ``[Ex, Ey, Hx, Hy]`` and partial-wave sort
+(``WaveProfile.tangential_modes``: columns ``[t0, t1, r0, r1]`` = forward,
+forward, backward, backward). Per-medium eigenvectors come from each layer's
+``profile`` (interior layers and a semi-infinite crystal exit) or from the
+ambient dynamical matrices ``A_inc`` / ``A_exit`` (prism, isotropic exit).
+"""
+
+import numpy as np
+
+from hyperbolic_optics.axes import assert_canonical
+
+# Ambient (isotropic) dynamical matrices have columns [s_fwd, s_bwd, p_fwd,
+# p_bwd]; reorder to the forward/backward grouping [p_fwd, s_fwd, p_bwd, s_bwd]
+# used here (forward = columns 0,1; backward = columns 2,3).
+_AMBIENT_REORDER = [2, 0, 3, 1]
+
+
+def _diag(values: np.ndarray) -> np.ndarray:
+    """Build batched diagonal 4×4 matrices from ``values`` shaped ``[..., 4]``."""
+    out = np.zeros(values.shape + (4,), dtype=np.complex128)
+    idx = np.arange(4)
+    out[..., idx, idx] = values
+    return out
+
+
+def _medium(layer) -> tuple[np.ndarray, np.ndarray | None, object]:
+    """Return ``(P, q, d)`` for a layer: eigenvectors, propagation kz, thickness.
+
+    ``q``/``d`` are ``None`` for half-spaces (prism, exit), whose propagation is
+    the identity. Columns of ``P`` are grouped forward (0,1) / backward (2,3).
+    """
+    profile = getattr(layer, "profile", None)
+    if profile is not None and layer.thickness is not None:
+        # interior finite layer (crystal or isotropic air gap)
+        eigenvectors, kz = profile.tangential_modes()
+        return eigenvectors, kz, layer.thickness
+    if profile is not None:
+        # semi-infinite anisotropic exit: half-space, no propagation
+        eigenvectors, _ = profile.tangential_modes()
+        return eigenvectors, None, None
+    # ambient isotropic half-space: prism.matrix = A_inc^{-1}; exit.matrix = A_exit.
+    matrix = layer.matrix
+    dynamical = np.linalg.inv(matrix) if layer.type == "Ambient Incident Layer" else matrix
+    return dynamical[..., :, _AMBIENT_REORDER], None, None
+
+
+def _interface_scattering(
+    p_left: np.ndarray,
+    q_left: np.ndarray | None,
+    d_left: object,
+    p_right: np.ndarray,
+    k_0: np.ndarray,
+) -> np.ndarray:
+    """Scattering matrix ``S`` between two media (PyLlama eqs 19-23).
+
+    ``[E_{right,→}; E_{left,←}] = S · [E_{left,→}; E_{right,←}]``. The propagation
+    of the *left* medium is applied as decaying exponentials only — the forward
+    factor ``exp(+i·q·k₀·d)`` (forward modes have ``Im(q) > 0``) and the backward
+    *inverse* ``exp(-i·q·k₀·d)`` (backward modes have ``Im(q) < 0``) are both ≤ 1,
+    and the growing matrices are never formed.
+    """
+    p_left, p_right = np.broadcast_arrays(p_left, p_right)
+    # P_out = [p_left,0, p_left,1, -p_right,2, -p_right,3]
+    p_out = np.stack(
+        [p_left[..., :, 0], p_left[..., :, 1], -p_right[..., :, 2], -p_right[..., :, 3]], axis=-1
+    )
+    # P_in = [p_right,0, p_right,1, -p_left,2, -p_left,3]
+    p_in = np.stack(
+        [p_right[..., :, 0], p_right[..., :, 1], -p_left[..., :, 2], -p_left[..., :, 3]], axis=-1
+    )
+
+    core = np.linalg.inv(p_in) @ p_out
+    if q_left is None:  # half-space: identity propagation
+        return core
+
+    k0_modes = k_0[..., np.newaxis]  # add a trailing mode axis -> [..., 1, 1]
+    thickness = d_left[..., np.newaxis] if np.ndim(d_left) > 0 else d_left
+    arg = q_left * k0_modes * thickness  # [..., 4]
+    ones = np.ones_like(arg[..., 0])
+    # Exponentiate only the modes that decay in their natural direction so the
+    # growing exponentials are never even formed: forward factor exp(+i·arg) for
+    # the forward modes (Im q > 0) and the backward *inverse* exp(-i·arg) for the
+    # backward modes (Im q < 0). Both are bounded by 1.
+    forward = np.exp(1j * arg[..., :2])
+    backward_inv = np.exp(-1j * arg[..., 2:])
+    q_forward = _diag(np.stack([forward[..., 0], forward[..., 1], ones, ones], axis=-1))
+    q_backward_inv = _diag(
+        np.stack([ones, ones, backward_inv[..., 0], backward_inv[..., 1]], axis=-1)
+    )
+    return q_backward_inv @ core @ q_forward
+
+
+def _star(s_a: np.ndarray, s_b: np.ndarray) -> np.ndarray:
+    """Redheffer star product of two scattering matrices (PyLlama eqs 25-26)."""
+    s00a, s01a, s10a, s11a = s_a[..., :2, :2], s_a[..., :2, 2:], s_a[..., 2:, :2], s_a[..., 2:, 2:]
+    s00b, s01b, s10b, s11b = s_b[..., :2, :2], s_b[..., :2, 2:], s_b[..., 2:, :2], s_b[..., 2:, 2:]
+    identity = np.eye(2, dtype=np.complex128)
+    c_inv = np.linalg.inv(identity - s01a @ s10b)
+    s00 = s00b @ c_inv @ s00a
+    s01 = s01b + s00b @ c_inv @ s01a @ s11b
+    s10 = s10a + s11a @ s10b @ c_inv @ s00a
+    s11 = s11a @ s11b + s11a @ s10b @ c_inv @ s01a @ s11b
+    top = np.concatenate([s00, s01], axis=-1)
+    bottom = np.concatenate([s10, s11], axis=-1)
+    return np.concatenate([top, bottom], axis=-2)
+
+
+def scattering_coefficients(layers: list, k_0: np.ndarray) -> dict[str, np.ndarray]:
+    """Reflection/transmission coefficients via the stable scattering-matrix method.
+
+    Args:
+        layers: The executed structure's layers (``structure.layers``), each
+            exposing eigenvectors via ``profile`` or an ambient dynamical matrix.
+        k_0: Canonical free-space wavenumber ``[1, 1, F, 1]``.
+
+    Returns:
+        Dict of the eight complex coefficients ``r_pp, r_ss, r_ps, r_sp, t_pp,
+        t_ss, t_ps, t_sp`` in canonical ``[A, B, F, T]`` layout (un-presented).
+
+    Note:
+        For an isotropic exit the transmission coefficients are in the clean s/p
+        basis; for a semi-infinite anisotropic exit they are in that crystal's
+        eigenmode basis (as in the transfer method), while the reflection
+        coefficients are always in the prism's s/p basis.
+    """
+    media = [_medium(layer) for layer in layers]
+    scattering = None
+    for (p_left, q_left, d_left), (p_right, _, _) in zip(media[:-1], media[1:], strict=True):
+        interface = _interface_scattering(p_left, q_left, d_left, p_right, k_0)
+        scattering = interface if scattering is None else _star(scattering, interface)
+
+    assert_canonical(scattering, matrix_ndim=2, name="scattering_matrix")
+    s = scattering
+    # PyLlama r_kj is (out k, in j); this codebase uses r_{in->out}, so the cross
+    # terms transpose (verified against the transfer backend).
+    return {
+        "r_pp": s[..., 2, 0],
+        "r_ss": s[..., 3, 1],
+        "r_ps": s[..., 3, 0],
+        "r_sp": s[..., 2, 1],
+        "t_pp": s[..., 0, 0],
+        "t_ss": s[..., 1, 1],
+        "t_ps": s[..., 1, 0],
+        "t_sp": s[..., 0, 1],
+    }

--- a/hyperbolic_optics/structure.py
+++ b/hyperbolic_optics/structure.py
@@ -26,6 +26,7 @@ import numpy as np
 from hyperbolic_optics.axes import A, F, assert_canonical, canonicalize, present
 from hyperbolic_optics.layers import LayerFactory
 from hyperbolic_optics.materials import create_material
+from hyperbolic_optics.scattering import scattering_coefficients
 from hyperbolic_optics.scenario import ScenarioSetup
 
 
@@ -353,11 +354,29 @@ class Structure:
         for layer in self.layers:
             print(layer)
 
-    def execute(self, payload: dict[str, Any]) -> None:
+    def calculate_scattering(self) -> None:
+        """Fill reflection/transmission coefficients via the scattering backend.
+
+        Uses :func:`hyperbolic_optics.scattering.scattering_coefficients` — a
+        numerically-stable Redheffer scattering-matrix cascade built from each
+        layer's eigenmodes — instead of the transfer-matrix product. Sets
+        ``r_pp … t_ss`` in the same presentation layout as
+        :meth:`calculate_reflectivity`.
+        """
+        coefficients = scattering_coefficients(self.layers, self.k_0)
+        for name, value in coefficients.items():
+            setattr(self, name, present(value))
+
+    def execute(self, payload: dict[str, Any], backend: str = "transfer") -> None:
         """Execute complete simulation from configuration payload.
 
         Args:
-            payload: Dictionary with 'ScenarioData' and 'Layers' keys
+            payload: Dictionary with 'ScenarioData' and 'Layers' keys.
+            backend: ``"transfer"`` (default) for the 4×4 transfer-matrix product,
+                or ``"scattering"`` for the numerically-stable scattering-matrix
+                backend (correct for thick / lossy / strongly-evanescent stacks
+                where the transfer product overflows). Both yield the same
+                coefficients where the transfer method is well-conditioned.
 
         Example:
             >>> payload = {
@@ -373,10 +392,24 @@ class Structure:
             >>> structure.execute(payload)
             >>> R_pp = abs(structure.r_pp)**2
         """
+        if backend not in ("transfer", "scattering"):
+            raise ValueError(f"Unknown backend {backend!r}; use 'transfer' or 'scattering'.")
+
         # Get the scenario data
         self.get_scenario(payload.get("ScenarioData"))
 
-        # Get the layers
+        if backend == "scattering":
+            # The per-layer transfer matrices built in get_layers can overflow for
+            # thick/evanescent layers -- harmless here, since the scattering
+            # backend reads each layer's eigenmodes (profile), not its matrix. The
+            # errstate silences that expected overflow (the scattering engine
+            # itself never forms a growing exponential).
+            with np.errstate(over="ignore", invalid="ignore"):
+                self.get_layers(payload.get("Layers", None))
+                self.calculate_scattering()
+            return
+
+        # Get the layers (builds each layer's eigenmodes / matrices)
         self.get_layers(payload.get("Layers", None))
 
         # Calculate the transfer matrix

--- a/tests/test_scattering.py
+++ b/tests/test_scattering.py
@@ -1,0 +1,165 @@
+"""Tests for the numerically-stable scattering-matrix backend.
+
+The correctness anchor is that the scattering backend reproduces the (golden-
+locked) transfer-matrix reflection coefficients wherever the transfer method is
+well-conditioned; the payoff is that it stays finite and energy-conserving in the
+thick-evanescent regime where the transfer product overflows to NaN.
+"""
+
+import numpy as np
+import pytest
+
+from hyperbolic_optics.axes import present
+from hyperbolic_optics.structure import Structure
+from tests.golden.payloads import PAYLOADS, SLOW_PAYLOADS
+
+
+def _run(payload, backend):
+    structure = Structure()
+    structure.execute(payload, backend=backend)
+    return structure
+
+
+class TestCrossCheckVsTransfer:
+    """Scattering r-coefficients match the transfer backend across the battery."""
+
+    @pytest.mark.parametrize("name", [n for n in PAYLOADS if n not in SLOW_PAYLOADS])
+    def test_reflection_matches(self, name):
+        transfer = _run(PAYLOADS[name], "transfer")
+        scattering = _run(PAYLOADS[name], "scattering")
+        # Only require agreement where the transfer matrix is well-conditioned:
+        # at near-grazing / deep-evanescent points Gamma is (near-)singular and the
+        # transfer coefficients are unreliable -- that is precisely where the
+        # scattering method is the correct one (covered by TestStability).
+        cond = present(np.linalg.cond(np.asarray(transfer.transfer_matrix)))
+        reliable = np.asarray(cond) < 1e10
+        for key in ("r_pp", "r_ss", "r_ps", "r_sp"):
+            a = np.asarray(getattr(transfer, key))
+            b = np.asarray(getattr(scattering, key))
+            ok = np.isclose(a, b, atol=1e-7, rtol=1e-5) | ~reliable | ~np.isfinite(a)
+            assert np.all(ok), f"{key}: {np.count_nonzero(~ok)} mismatches"
+
+    def test_transmission_matches_for_isotropic_exit(self):
+        # Transmission is in the clean s/p basis only for an isotropic exit, so
+        # compare t there (crystal-exit t is in the eigenmode basis for both).
+        payload = {
+            "ScenarioData": {
+                "type": "Simple",
+                "incidentAngle": 30.0,
+                "azimuthal_angle": 0.0,
+                "frequency": 1460.0,
+            },
+            "Layers": [
+                {"type": "Ambient Incident Layer", "permittivity": 25.0},
+                {"type": "Crystal Layer", "material": "Calcite", "thickness": 1.0, "rotationY": 90},
+                {"type": "Semi Infinite Isotropic Layer", "permittivity": 1.0},
+            ],
+        }
+        transfer = _run(payload, "transfer")
+        transfer.calculate_transmissivity()
+        scattering = _run(payload, "scattering")
+        for key in ("t_pp", "t_ss", "t_ps", "t_sp"):
+            assert complex(getattr(scattering, key)) == pytest.approx(
+                complex(getattr(transfer, key)), abs=1e-7
+            ), key
+
+
+def _otto_gap(gap_um):
+    return {
+        "ScenarioData": {
+            "type": "Simple",
+            "incidentAngle": 45.0,
+            "azimuthal_angle": 0.0,
+            "frequency": 1460.0,
+        },
+        "Layers": [
+            {"type": "Ambient Incident Layer", "permittivity": 50.0},
+            {"type": "Isotropic Middle-Stack Layer", "thickness": gap_um, "permittivity": 1.0},
+            {"type": "Semi Infinite Anisotropic Layer", "material": "Calcite", "rotationY": 90},
+        ],
+    }
+
+
+class TestStability:
+    """The whole point: stable where the transfer matrix overflows."""
+
+    def test_thick_evanescent_gap(self):
+        # kx = sqrt(50)*sin45 ~ 5 >> 1, so a thick air gap is deeply evanescent.
+        transfer = _run(_otto_gap(250.0), "transfer")
+        scattering = _run(_otto_gap(250.0), "scattering")
+        # transfer product overflows -> non-finite
+        assert not np.isfinite(complex(transfer.r_pp))
+        # scattering stays finite and physical: frustrated TIR vanishes -> R -> 1
+        r = complex(scattering.r_pp)
+        assert np.isfinite(r)
+        reflectance = abs(r) ** 2 + abs(complex(scattering.r_sp)) ** 2
+        assert reflectance == pytest.approx(1.0, abs=1e-6)
+
+    def test_thin_gap_agrees_with_transfer(self):
+        # where the transfer method works, the two backends agree.
+        transfer = _run(_otto_gap(1.0), "transfer")
+        scattering = _run(_otto_gap(1.0), "scattering")
+        assert complex(scattering.r_pp) == pytest.approx(complex(transfer.r_pp), abs=1e-8)
+
+
+class TestEnergyConservation:
+    """Lossless symmetric (prism == substrate) stack: R + T == 1."""
+
+    def test_symmetric_lossless(self):
+        payload = {
+            "ScenarioData": {
+                "type": "Simple",
+                "incidentAngle": 20.0,
+                "azimuthal_angle": 0.0,
+                "frequency": 1460.0,
+            },
+            "Layers": [
+                {"type": "Ambient Incident Layer", "permittivity": 2.0},
+                {"type": "Isotropic Middle-Stack Layer", "thickness": 0.8, "permittivity": 1.0},
+                {"type": "Semi Infinite Isotropic Layer", "permittivity": 2.0},
+            ],
+        }
+        s = _run(payload, "scattering")
+        # symmetric prism == substrate -> the |t|^2 impedance factor is 1
+        r_p = abs(complex(s.r_pp)) ** 2 + abs(complex(s.r_sp)) ** 2
+        t_p = abs(complex(s.t_pp)) ** 2 + abs(complex(s.t_sp)) ** 2
+        assert r_p + t_p == pytest.approx(1.0, abs=1e-9)
+
+
+class TestScenarios:
+    """Scattering matches transfer across scenarios and shapes."""
+
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            {"type": "Incident"},
+            {"type": "Azimuthal", "incidentAngle": 40},
+            {"type": "Dispersion", "frequency": 1460.0},
+        ],
+    )
+    def test_matches_across_scenarios(self, scenario):
+        payload = {
+            "ScenarioData": scenario,
+            "Layers": [
+                {"type": "Ambient Incident Layer", "permittivity": 12.5},
+                {"type": "Isotropic Middle-Stack Layer", "thickness": 0.5},
+                {"type": "Semi Infinite Anisotropic Layer", "material": "Calcite", "rotationY": 90},
+            ],
+        }
+        transfer = _run(payload, "transfer")
+        scattering = _run(payload, "scattering")
+        assert scattering.r_pp.shape == transfer.r_pp.shape
+        assert np.allclose(scattering.r_pp, transfer.r_pp, atol=1e-7, rtol=1e-5)
+
+
+class TestGuards:
+    def test_unknown_backend_raises(self):
+        with pytest.raises(ValueError, match="backend"):
+            _run(_otto_gap(1.0), "bogus")
+
+    def test_transfer_is_default(self):
+        # execute() without a backend arg behaves as the transfer backend.
+        default = Structure()
+        default.execute(_otto_gap(1.0))
+        explicit = _run(_otto_gap(1.0), "transfer")
+        assert complex(default.r_pp) == pytest.approx(complex(explicit.r_pp), abs=0)


### PR DESCRIPTION
execute(payload, backend="scattering") computes reflection/transmission via a Redheffer scattering-matrix cascade instead of the 4x4 transfer-matrix product. Only decaying exponentials ever appear (the growing matrices are never formed), so it is stable for thick / lossy / strongly-evanescent stacks where the transfer product overflows to NaN or Gamma goes (near-)singular.

- New hyperbolic_optics/scattering.py: per-medium eigenvectors (from each layer's WaveProfile, or the ambient A_inc/A_exit dynamical matrices), per-interface scattering matrices (PyLlama eqs 19-23), Redheffer star product (eqs 25-26), and r/t extraction (eq 28), fully batched over the canonical [A, B, F, T] axes.
- structure.execute gains backend= ("transfer" default, unchanged behaviour and golden snapshots; "scattering" opt-in). The transfer matrix built during get_layers is unused under scattering, so its expected overflow is silenced.
- Scope v1: stable r/t coefficients and the power that derives from them; depth-resolved FieldProfile stays on the transfer path.

Validated: scattering matches transfer wherever Gamma is well-conditioned (golden battery cross-check, masked on cond(Gamma)); a thick evanescent Otto gap gives NaN on transfer but correct total reflection on scattering. Algorithm/conventions follow PyLlama (Bay et al., J. Opt. Soc. Am. A 39, 1431 (2022); arXiv:2012.05945). Full suite: 189 passing.